### PR TITLE
Added CODEOWNERS file so reviewers will be automatically tagged

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aws-geospatial/amazon-location


### PR DESCRIPTION
## Description
Added `CODEOWNERS` file so that the `@aws-geospatial/amazon-location` team will be automatically added as reviewers for new PRs.