### PR TITLE
Added config options and other small fixes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,7 @@ module.exports = {
       files: ["test-utils.ts", "**/*.test.ts"],
       rules: {
         "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-empty-function": "off",
       },
     },
   ],

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -348,4 +348,6 @@ export interface PlacesGeocoderOptions {
   enableReverseGeocode?: boolean;
   enableGetSuggestions?: boolean;
   enableSearchByPlaceId?: boolean;
+  omitSuggestionsWithoutPlaceId?: boolean;
+  placeholder?: string;
 }

--- a/src/geocoder/index.test.ts
+++ b/src/geocoder/index.test.ts
@@ -6,6 +6,7 @@ import {
   SearchPlaceIndexForTextCommand,
 } from "@aws-sdk/client-location";
 import { withAPIKey, withIdentityPoolId } from "@aws/amazon-location-utilities-auth-helper";
+import MaplibreGeocoder from "@maplibre/maplibre-gl-geocoder";
 import { AmazonLocationMaplibreGeocoder, buildAmazonLocationMaplibreGeocoder } from "./index";
 import { BoundingBox, CategoriesEnum, CountriesEnum, Position } from "../common/types";
 import {
@@ -22,8 +23,12 @@ export interface AmazonLocationMaplibreGeocoderParams {
   identityPoolId?: string;
 }
 
+jest.spyOn(console, "warn").mockImplementation(() => {});
+jest.spyOn(console, "error").mockImplementation(() => {});
+
 jest.mock("@aws-sdk/client-location");
 jest.mock("@aws/amazon-location-utilities-auth-helper");
+jest.mock("@maplibre/maplibre-gl-geocoder");
 
 describe("Creates APIs for Maplibre Geocoder using Amazon Location APIs", () => {
   const PLACES_NAME = "places.name";
@@ -54,6 +59,10 @@ describe("Creates APIs for Maplibre Geocoder using Amazon Location APIs", () => 
         };
       },
     });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it("AmazonLocationMaplibreGeocoder should throw error if you try to initialized it without passing in api's", () => {
@@ -660,5 +669,17 @@ describe("Creates APIs for Maplibre Geocoder using Amazon Location APIs", () => 
     // Clear all filters
     geocoder.clearFilters();
     expect(geocoder.getBiasPosition()).toStrictEqual(null);
+  });
+
+  it("placeholder should be passed to MaplibreGeocoder when specified.", async () => {
+    buildAmazonLocationMaplibreGeocoder(clientMock, PLACES_NAME, {
+      placeholder: "Test Placeholder",
+    });
+
+    expect(MaplibreGeocoder).toHaveBeenCalledTimes(1);
+
+    // The options are the second argument to MaplibreGeocoder
+    const options = MaplibreGeocoder.mock.calls[0][1];
+    expect(options.placeholder).toStrictEqual("Test Placeholder");
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,4 +8,8 @@ describe("Exported class", () => {
   it("Should export buildAmazonLocationMaplibreGeocoder", () => {
     expect("buildAmazonLocationMaplibreGeocoder" in amazonLocationMaplibreGeocoder).toBe(true);
   });
+
+  it("Should export PlacesGeocoderOptions", () => {
+    expect("PlacesGeocoderOptions" in amazonLocationMaplibreGeocoder).toBe(true);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import { AmazonLocationMaplibreGeocoder, buildAmazonLocationMaplibreGeocoder } from "./geocoder";
+import { PlacesGeocoderOptions } from "./common/types";
 
-export { AmazonLocationMaplibreGeocoder, buildAmazonLocationMaplibreGeocoder };
+export { AmazonLocationMaplibreGeocoder, buildAmazonLocationMaplibreGeocoder, PlacesGeocoderOptions };


### PR DESCRIPTION
## Description
Added some more configuration options, and other small fixes:
* Added `omitSuggestionsWithoutPlaceId` option to omit suggestions that don't have a `PlaceId` (e.g. query string suggestions, such as "pizza near me")
* Added `placeholder` option to override the string placeholder text in the `input` field
* Added full `result` in the optional `properties` in the responses, so the user can access all fields
* Exported `PlacesGeocoderOptions` so that users can access the configuration options type
* Updated unit tests to clear mocks after each run
* Added mocks for `console.warn` and `console.error` so they don't spam the unit test output
* Removed a number of `console.log` debug prints that were left behind
* Converted several `console.log` messages to `console.warn`

## Testing
Built/ran unit tests. Also tested by using the geocoder in local sample application.