### PR TITLE
Added esModuleInterop to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2017",
     "moduleResolution": "node",
     "outDir": "dist",
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true
   },
   "typedocOptions": {


### PR DESCRIPTION
## Description
Set `esModuleInterop` to `true` in our `tsconfig`. This is to account for `.default is not a constructor` error that downstream packages might encounter when using our package, since the underlying package we use( https://github.com/maplibre/maplibre-gl-geocoder) is a pure javascript library that uses `module.exports`.

## Testing
Built/ran unit tests, and tested usage of this package in a downstream module.