### PR TITLE
Include PlaceId in properties when retrieving by PlaceId

### DIFF
--- a/src/geocoder/index.test.ts
+++ b/src/geocoder/index.test.ts
@@ -307,12 +307,8 @@ describe("Creates APIs for Maplibre Geocoder using Amazon Location APIs", () => 
 
   it("searchByPlaceId should return data in expected format WHEN given valid credentials.", async () => {
     const config = {
-      query: "a map query",
+      query: "A_PLACE_ID",
       language: "en",
-      types: "",
-      countries: "",
-      proximity: {},
-      bbox: [],
     };
 
     const geocoder = buildAmazonLocationMaplibreGeocoder(clientMock, PLACES_NAME, {
@@ -334,16 +330,13 @@ describe("Creates APIs for Maplibre Geocoder using Amazon Location APIs", () => 
 
     expect(response.place.place_name).toEqual("Small Town");
     expect(response.place.geometry.coordinates).toEqual([123, 456]);
+    expect(response.place.properties.PlaceId).toStrictEqual("A_PLACE_ID");
   });
 
   it("searchByPlaceId throws error when error is encountered", async () => {
     const config = {
-      query: "a map query",
+      query: "A_PLACE_ID",
       language: "en",
-      types: "",
-      countries: "",
-      proximity: {},
-      bbox: [],
     };
 
     const geocoder = buildAmazonLocationMaplibreGeocoder(clientMock, PLACES_NAME, {

--- a/src/geocoder/index.ts
+++ b/src/geocoder/index.ts
@@ -436,11 +436,12 @@ function createAmazonLocationSearchPlaceById(amazonLocationClient: LocationClien
   const client = amazonLocationClient;
   return async function (config) {
     let feature;
+    const placeId = config.query;
     try {
       // Set up parameters for search call
       const getPlaceParams: GetPlaceCommandInput = {
         IndexName: placesName,
-        PlaceId: config.query,
+        PlaceId: placeId,
         // Maplibre-gl-geocoder stores the language value as an array of language codes. Amazon Location only supports a single language at a time.
         Language: config.language[0],
       };
@@ -458,6 +459,7 @@ function createAmazonLocationSearchPlaceById(amazonLocationClient: LocationClien
         place_name: data.Place.Label,
         properties: {
           ...data,
+          PlaceId: placeId,
         },
         text: data.Place.Label,
         center: data.Place.Geometry.Point,


### PR DESCRIPTION
## Description
Include the `PlaceId` in properties when retrieving by `PlaceId` to match Amazon Location place format, since it's omitted for this particular request.

## Testing
Built/ran unit tests. Updated `searchByPlaceId` unit tests with expected request fields.