### PR TITLE
Release version bump: `1.0.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/amazon-location-for-maplibre-gl-geocoder",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/amazon-location-for-maplibre-gl-geocoder",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@aws-sdk/client-location": "^3.564.0",
         "@aws/amazon-location-utilities-auth-helper": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/amazon-location-for-maplibre-gl-geocoder",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Maplibre Plugin to Support Amazon Location Service Integration",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
## Description
Bump version number to release PlaceId fix: https://github.com/aws-geospatial/amazon-location-for-maplibre-gl-geocoder/pull/91