### PR TITLE
Adding grouping so that dependency updates get grouped into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description
With this configuration, dependabot will run dependency minor/patch version updates once a week, and will group all the changes into a single PR.