### PR TITLE
Updated our geocoder to use the new version of maplibre geocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ npm run typedoc
 
 ### `buildAmazonLocationMaplibreGeocoder`
 
-Creates an instance of the AmazonLocationMaplibreGeocder which is the entry point to the other all other calls.
+Creates an instance of the AmazonLocationMaplibreGeocoder which is the entry point to the other all other calls.
 
 ```javascript
 const amazonLocationMaplibreGeocoder = buildAmazonLocationMaplibreGeocoder(client, placesIndex, { enableAll: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-location": "^3.621.0",
         "@aws/amazon-location-utilities-auth-helper": "^1.0.7",
         "@aws/amazon-location-utilities-datatypes": "^1.0.5",
-        "@maplibre/maplibre-gl-geocoder": "^1.5.0"
+        "@maplibre/maplibre-gl-geocoder": "^1.6.0"
       },
       "devDependencies": {
         "@babel/core": "^7.24.4",
@@ -4088,40 +4088,49 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-geocoder": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-geocoder/-/maplibre-gl-geocoder-1.5.0.tgz",
-      "integrity": "sha512-PsAbV7WFIOu5QYZne95FiXoV7AV1/6ULMjQxgInhZ5DdB0hDLjciQPegnyDgkzI8JfeqoUMZVS/MglZnSZYhyQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-geocoder/-/maplibre-gl-geocoder-1.6.0.tgz",
+      "integrity": "sha512-SU4cv1P+8ALZlGYLPNvlENadH4zzn8Lw5ajmhbmJgWdC/NzxGFS+u4TITSL8tjzhMFU4jepo42HvNmGtDJjFuQ==",
       "dependencies": {
+        "events": "^3.3.0",
         "lodash.debounce": "^4.0.6",
         "subtag": "^0.5.0",
         "suggestions-list": "^0.0.2",
         "xtend": "^4.0.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "maplibre-gl": ">=1.14.0"
+        "maplibre-gl": ">=4.0.0"
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.2",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.2.tgz",
-      "integrity": "sha512-C2JAk64XUz9v78+bpyTk1zvgjjnDsB8CCjNumyAYdWK2dvdDtILzh1AGBMdS/llX3KaHjGYxAE5wOwfdwq4Pog==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.3.1.tgz",
+      "integrity": "sha512-5ueL4UDitzVtceQ8J4kY+Px3WK+eZTsmGwha3MBKHKqiHvKrjWWwBCIl1K8BuJSc5OFh83uI8IFNoFvQxX2uUw==",
       "peer": true,
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
-        "json-stringify-pretty-compact": "^3.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
+        "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "sort-object": "^3.0.3"
+        "sort-object": "^3.0.3",
+        "tinyqueue": "^3.0.0"
       },
       "bin": {
         "gl-style-format": "dist/gl-style-format.mjs",
         "gl-style-migrate": "dist/gl-style-migrate.mjs",
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "peer": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5344,9 +5353,18 @@
       "dev": true
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.11",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.11.tgz",
-      "integrity": "sha512-L7A0AINMXQpVwxHJ4jxD6/XjZ4NDufaRlUJHjNIFKYUFBH1SvOW+neaqb0VTRSLW5suSrSu19ObFEFnfNcr+qg=="
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.7",
@@ -5392,15 +5410,15 @@
       }
     },
     "node_modules/@types/mapbox__point-geometry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-      "integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
       "peer": true
     },
     "node_modules/@types/mapbox__vector-tile": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.1.tgz",
-      "integrity": "sha512-RpwGE57xM4a/YCH6XWzfcPVRPAu/jiCll0bEGRn6a4iubN2k4xZizskQoRj8fuXyo9BpI7F3bwz3uxs0pWbGNw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
       "peer": true,
       "dependencies": {
         "@types/geojson": "*",
@@ -5433,9 +5451,9 @@
       }
     },
     "node_modules/@types/pbf": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.3.tgz",
-      "integrity": "sha512-hw6bDMjvm+QTvEC+pRLpnTknQXoPu8Fnf+A+zX9HB7j/7RfYajFSbdukabo3adPwvvEHhIMafQl0R0Tpej7clQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
       "peer": true
     },
     "node_modules/@types/resolve": {
@@ -5451,9 +5469,9 @@
       "dev": true
     },
     "node_modules/@types/supercluster": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.1.tgz",
-      "integrity": "sha512-dNK02GO1UApgo+1KpY4jOfm3uWb2eBCMB/VMM2y8cMoF49FiqVVcOawEg19wxYcaX7SvEs370incOuFtFGrVLg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
       "peer": true,
       "dependencies": {
         "@types/geojson": "*"
@@ -6816,9 +6834,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-41Fs7Q/PLq1SDbqjsgcY7GA42T0jvaCNGXgGtsNdvg+Yv8eIu06bxv4/PoREkZ9nMDNwnUSG9OFB9+yv8eKhDg==",
       "peer": true
     },
     "node_modules/eastasianwidth": {
@@ -7277,6 +7295,14 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7623,9 +7649,9 @@
       }
     },
     "node_modules/geojson-vt": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
       "peer": true
     },
     "node_modules/get-caller-file": {
@@ -7774,29 +7800,41 @@
       }
     },
     "node_modules/global-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
+      "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
       "peer": true,
       "dependencies": {
-        "ini": "^1.3.5",
-        "kind-of": "^6.0.2",
-        "which": "^1.3.1"
+        "ini": "^4.1.3",
+        "kind-of": "^6.0.3",
+        "which": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=16"
+      }
+    },
+    "node_modules/global-prefix/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/global-prefix/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "peer": true,
       "dependencies": {
-        "isexe": "^2.0.0"
+        "isexe": "^3.1.1"
       },
       "bin": {
-        "which": "bin/which"
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/globals": {
@@ -8071,10 +8109,13 @@
       "dev": true
     },
     "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "peer": true
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "peer": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -8421,7 +8462,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -10336,9 +10378,9 @@
       "dev": true
     },
     "node_modules/json-stringify-pretty-compact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
-      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "peer": true
     },
     "node_modules/json5": {
@@ -10889,9 +10931,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.5.0.tgz",
-      "integrity": "sha512-kPEBz6r1LBOZjUpFy+4wZU5Nvnkr60wBtYN/JD6N7oaA4Prpe21afYKxi1oWzSPSfspS1tWNF18GlpF2XcmNSA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.6.0.tgz",
+      "integrity": "sha512-zobZK+fE+XM+7K81fk5pSBYWZlTGjGT0P96y2fR4DV2ry35ZBfAd0uWNatll69EgYeE+uOhN1MvEk+z1PCuyOQ==",
       "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
@@ -10901,23 +10943,24 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^19.3.2",
-        "@types/geojson": "^7946.0.11",
-        "@types/mapbox__point-geometry": "^0.1.2",
-        "@types/mapbox__vector-tile": "^1.3.1",
-        "@types/pbf": "^3.0.3",
-        "@types/supercluster": "^7.1.1",
-        "earcut": "^2.2.4",
-        "geojson-vt": "^3.2.1",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "earcut": "^3.0.0",
+        "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
-        "global-prefix": "^3.0.0",
+        "global-prefix": "^4.0.0",
         "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
+        "pbf": "^3.3.0",
         "potpack": "^2.0.0",
-        "quickselect": "^2.0.0",
+        "quickselect": "^3.0.0",
         "supercluster": "^8.0.1",
-        "tinyqueue": "^2.0.3",
+        "tinyqueue": "^3.0.0",
         "vt-pbf": "^3.1.3"
       },
       "engines": {
@@ -11455,9 +11498,9 @@
       ]
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
@@ -11914,9 +11957,9 @@
       }
     },
     "node_modules/pbf": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
       "peer": true,
       "dependencies": {
         "ieee754": "^1.1.12",
@@ -12185,9 +12228,9 @@
       ]
     },
     "node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
       "peer": true
     },
     "node_modules/react-is": {
@@ -13184,9 +13227,9 @@
       "dev": true
     },
     "node_modules/tinyqueue": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "peer": true
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@aws-sdk/client-location": "^3.621.0",
     "@aws/amazon-location-utilities-auth-helper": "^1.0.7",
     "@aws/amazon-location-utilities-datatypes": "^1.0.5",
-    "@maplibre/maplibre-gl-geocoder": "^1.5.0"
+    "@maplibre/maplibre-gl-geocoder": "^1.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.4",

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -336,16 +336,8 @@ export interface BoundingBox {
   latitudeNE: number;
 }
 
-export interface AmazonLocationGeocoderApi {
-  forwardGeocode?;
-  reverseGeocode?;
-  getSuggestions?;
-  searchByPlaceId?;
-}
-
 export interface PlacesGeocoderOptions {
   enableAll?: boolean;
-  enableReverseGeocode?: boolean;
   enableGetSuggestions?: boolean;
   enableSearchByPlaceId?: boolean;
   omitSuggestionsWithoutPlaceId?: boolean;


### PR DESCRIPTION
## Description
Updated our geocoder to use the latest version of the maplibre-geocoder.
* Maplibre's geocoder was updated to typescript, so fixed several issues related to using their types directly
* They now require `reverseGeocode` so it is no longer optional
* Fixed a couple of typos