### PR TITLE
Bumped maplibre/maplibre-gl-geocoder version from 1.7.0 to 1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.683.0",
         "@aws-sdk/client-location": "^3.682.0",
-        "@maplibre/maplibre-gl-geocoder": "^1.7.0"
+        "@maplibre/maplibre-gl-geocoder": "^1.7.1"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aws-sdk/client-geo-places": "^3.683.0",
     "@aws-sdk/client-location": "^3.682.0",
-    "@maplibre/maplibre-gl-geocoder": "^1.7.0"
+    "@maplibre/maplibre-gl-geocoder": "^1.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",


### PR DESCRIPTION
Bumped maplibre/maplibre-gl-geocoder version from 1.7.0 to 1.7.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
