### PR TITLE
Create remove-inactive-issues.yml

### DIFF
--- a/.github/workflows/remove-inactive-issues.yml
+++ b/.github/workflows/remove-inactive-issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Leverages this github action: https://github.com/marketplace/actions/close-stale-issues 

To schedule a check on the open issues daily at 1:30 UTC 
Marks issues that have no activity after 30 days as stale
Removes stale marked issues with no additional activity after 14 days. 

This will automate the process of closing issues that may be resolved, but have not received confirmation from the customer that wrote the issue helping maintain the repos stale issues without needing to remember a particular date. 