### PR TITLE
Release new version `2.0.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.3
+### ✨ Features and improvements
+- Added support for specifying `AdditionalFeatures` to expand response fields [#197](https://github.com/aws-geospatial/amazon-location-for-maplibre-gl-geocoder/pull/197)
+- Several dependency version updates
+
 # 2.0.2
 ### ✨ Features and improvements
 - Added support for `AutocompleteCommand` [#193](https://github.com/aws-geospatial/amazon-location-for-maplibre-gl-geocoder/pull/193)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/amazon-location-for-maplibre-gl-geocoder",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/amazon-location-for-maplibre-gl-geocoder",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@aws-sdk/client-geo-places": "^3.683.0",
         "@aws-sdk/client-location": "^3.682.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/amazon-location-for-maplibre-gl-geocoder",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Maplibre Plugin to Support Amazon Location Service Integration",
   "browser": "./dist/amazonLocationMaplibreGeocoder.js",
   "main": "./dist/cjs/index.js",


### PR DESCRIPTION
### Description
Release new version with the following improvements:
- Added support for specifying `AdditionalFeatures` to expand response fields [#197](https://github.com/aws-geospatial/amazon-location-for-maplibre-gl-geocoder/pull/197)
- Several dependency version updates