### PR TITLE
fix(github): reduced workflow permission scope

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: read
+      packages: write # for publishing package to github
     uses: aws-geospatial/github-workflows-for-amazon-location/.github/workflows/node-release.yml@main
     secrets:
       NPM_ORG_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}


### PR DESCRIPTION
*Issue #, if available:*

Resolve code scan results

*Description of changes:*

Reduce scope of github workflow permissions to read only except for writing on package publish

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
