### PR TITLE
feat: add npm-audit-check workflow

### DIFF
--- a/.github/workflows/npm-audit-check.yml
+++ b/.github/workflows/npm-audit-check.yml
@@ -1,0 +1,11 @@
+name: NPM Audit Check
+on:
+  schedule:
+    - cron: "30 16 * * 5" # Every Friday 11:30 CT (16:30 UTC during CDT, 10:30 CT during CST)
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+jobs:
+  run:
+    uses: aws-geospatial/github-workflows-for-amazon-location/.github/workflows/npm-audit-check.yml@main


### PR DESCRIPTION
## Summary

Adds a scheduled weekly [npm audit](https://docs.npmjs.com/cli/v10/commands/npm-audit) check for this repo's published package, via the shared reusable workflow in [`aws-geospatial/github-workflows-for-amazon-location`](https://github.com/aws-geospatial/github-workflows-for-amazon-location/blob/main/.github/workflows/npm-audit-check.yml).

## What it does

- Every Friday at 11:30 AM CT, installs the latest published version of this repo's npm package in an isolated environment and runs `npm audit`.
- If vulnerabilities are found: opens (or updates) a single rolling GitHub issue in this repo labeled `npm-audit`, with a table of advisories, severities, and CVE links.
- When vulnerabilities are resolved (e.g. a patched version is published): the rolling issue is auto-closed.
- Can also be triggered manually via **Actions → NPM Audit Check → Run workflow**.

## Schedule

Cron: `30 16 * * 5` UTC — every Friday 11:30 AM CT during CDT (10:30 AM CT during CST — 1-hour seasonal drift accepted).

## Validation

The reusable workflow was end-to-end validated in a sibling repo against a known-vulnerable package (`response.@2.88.2`, critical prototype pollution): issue creation, rolling-edit, and auto-close paths all confirmed working.