### PR TITLE
Add two workflows; one to automate release, the second to retry failed dependabot pr creation

### DIFF
--- a/.github/workflows/auto-security-release.yml
+++ b/.github/workflows/auto-security-release.yml
@@ -1,0 +1,24 @@
+name: Auto Security Release
+permissions:
+  contents: write
+  pull-requests: write
+on:
+  schedule:
+    - cron: "0 19 * * 1" # Every Monday at 2pm UTC-5 (7pm UTC)
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Force release even with non-dependabot commits"
+        type: boolean
+        default: false
+jobs:
+  run:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: aws-geospatial/github-workflows-for-amazon-location/.github/workflows/auto-security-release.yml@main
+    with:
+      force: ${{ inputs.force || false }}
+    secrets:
+      APP_ID: ${{ secrets.AUTO_RELEASE_BOT_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.AUTO_RELEASE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/dependabot-retry.yml
+++ b/.github/workflows/dependabot-retry.yml
@@ -1,0 +1,17 @@
+name: Dependabot Auto Retry
+permissions:
+  security-events: write
+  pull-requests: read
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+jobs:
+  run:
+    permissions:
+      security-events: write
+      pull-requests: read
+    uses: aws-geospatial/github-workflows-for-amazon-location/.github/workflows/dependabot-retry.yml@main
+    secrets:
+      APP_ID: ${{ secrets.AUTO_RELEASE_BOT_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.AUTO_RELEASE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The two workflows reduce operational burden by automating re-runs of failed dependabot pr creations as well as creating release PRs for security patches

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
